### PR TITLE
Update MDVA-38346_2.4.1.patch

### DIFF
--- a/patches/os/MDVA-38346_2.4.1.patch
+++ b/patches/os/MDVA-38346_2.4.1.patch
@@ -383,7 +383,7 @@ index 000000000000..3b9afb136b8b
 +                }
 +            }
 +
-+            $fieldName = $subject->getConnection()->quoteIdentifier($field);
++            $fieldName = "main_table.".$subject->getConnection()->quoteIdentifier($field);
 +            $condition = $subject->getConnection()->prepareSqlCondition($fieldName, $condition);
 +            $subject->getSelect()->where($condition, null, Select::TYPE_CONDITION);
 +


### PR DESCRIPTION
fix on the patch outcome so that it permits alterations of the sales order grid without creating errors on any types of joins with sales_order or any other type of table that has create_at and updated_at

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Please provide a description of the patches in the pull request. -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format: <jira_issue_link> <jira_issue_title>.
-->
1. <jira_issue_link> <jira_issue_title>
2. ...
